### PR TITLE
Fix Nuxt layout slot rendering

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
   <div>
-    <nuxt />
+    <slot />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- replace the deprecated `<nuxt />` component in the default layout with `<slot />` so Nuxt can render pages correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9cb3b05e88323b17ef09e4e01d4c2